### PR TITLE
Use 'descendants' instead of 'descendents' as method name for the des…

### DIFF
--- a/lib/pg_ltree/ltree.rb
+++ b/lib/pg_ltree/ltree.rb
@@ -109,7 +109,7 @@ module PgLtree
       #
       # @return [Number] height of the given node. Height of the tree for root node.
       def height
-        self_and_descendents.maximum("NLEVEL(#{ltree_path_column})") - depth.to_i
+        self_and_descendants.maximum("NLEVEL(#{ltree_path_column})") - depth.to_i
       end
 
       # Get node depth
@@ -161,18 +161,34 @@ module PgLtree
         self_and_ancestors.where.not ltree_path_column => ltree_path
       end
 
-      # Get self and descendents
+      # Get self and descendants
       #
       # @return [ActiveRecord::Relation]
-      def self_and_descendents
+      def self_and_descendants
         ltree_scope.where("#{ltree_path_column} <@ ?", ltree_path)
       end
 
-      # Get descendents
+      # Get self and descendants
+      # @deprecated Please use {#self_and_descendants} instead
+      # @return [ActiveRecord::Relation]
+      def self_and_descendents
+        warn '[DEPRECATION] `self_and_descendents` is deprecated. Please use `self_and_descendants` instead.'
+        self_and_descendants
+      end
+
+      # Get descendants
       #
       # @return [ActiveRecord::Relation]
+      def descendants
+        self_and_descendants.where.not ltree_path_column => ltree_path
+      end
+
+      # Get descendants
+      # @deprecated Please use {#descendants} instead
+      # @return [ActiveRecord::Relation]
       def descendents
-        self_and_descendents.where.not ltree_path_column => ltree_path
+        warn '[DEPRECATION] `descendents` is deprecated. Please use `descendants` instead.'
+        descendants
       end
 
       # Get self and siblings

--- a/test/pg_ltree/ltree_test.rb
+++ b/test/pg_ltree/ltree_test.rb
@@ -118,8 +118,8 @@ class PgLtree::LtreeTest < ActiveSupport::TestCase
     )
   end
 
-  test '.self_and_descendents' do
-    assert_equal TreeNode.find_by(path: 'Top.Science').self_and_descendents.pluck(:path), %w(
+  test '.self_and_descendants' do
+    assert_equal TreeNode.find_by(path: 'Top.Science').self_and_descendants.pluck(:path), %w(
       Top.Science
       Top.Science.Astronomy
       Top.Science.Astronomy.Astrophysics
@@ -127,8 +127,8 @@ class PgLtree::LtreeTest < ActiveSupport::TestCase
     )
   end
 
-  test '.descendents' do
-    assert_equal TreeNode.find_by(path: 'Top.Science').descendents.pluck(:path), %w(
+  test '.descendants' do
+    assert_equal TreeNode.find_by(path: 'Top.Science').descendants.pluck(:path), %w(
       Top.Science.Astronomy
       Top.Science.Astronomy.Astrophysics
       Top.Science.Astronomy.Cosmology
@@ -161,12 +161,12 @@ class PgLtree::LtreeTest < ActiveSupport::TestCase
     node = TreeNode.find_by(path: 'Top.Hobbies')
     node.update path: 'Top.WoW'
 
-    assert_equal node.self_and_descendents.pluck(:path), %w(
+    assert_equal node.self_and_descendants.pluck(:path), %w(
       Top.WoW
       Top.WoW.Amateurs_Astronomy
     )
   end
-  
+
   test '.cascade_destroy' do
     TreeNode.find_by(path: 'Top.Collections').destroy
 

--- a/test/pg_ltree/scoped_for_test.rb
+++ b/test/pg_ltree/scoped_for_test.rb
@@ -115,8 +115,8 @@ class PgLtree::ScopedForTest < ActiveSupport::TestCase
     )
   end
 
-  test '.self_and_descendents' do
-    assert_equal not_uniq_tree_node_find_by_path('Top.Science').self_and_descendents.pluck(:new_path), %w(
+  test '.self_and_descendants' do
+    assert_equal not_uniq_tree_node_find_by_path('Top.Science').self_and_descendants.pluck(:new_path), %w(
       Top.Science
       Top.Science.Astronomy
       Top.Science.Astronomy.Astrophysics
@@ -124,8 +124,8 @@ class PgLtree::ScopedForTest < ActiveSupport::TestCase
     )
   end
 
-  test '.descendents' do
-    assert_equal not_uniq_tree_node_find_by_path('Top.Science').descendents.pluck(:new_path), %w(
+  test '.descendants' do
+    assert_equal not_uniq_tree_node_find_by_path('Top.Science').descendants.pluck(:new_path), %w(
       Top.Science.Astronomy
       Top.Science.Astronomy.Astrophysics
       Top.Science.Astronomy.Cosmology
@@ -153,12 +153,12 @@ class PgLtree::ScopedForTest < ActiveSupport::TestCase
       Top.Hobbies.Amateurs_Astronomy
     )
   end
-  
+
   test '.cascade_update' do
     node = NotUniqTreeNode.find_by(new_path: 'Top.Hobbies', status: :active)
     node.update new_path: 'Top.WoW'
 
-    assert_equal node.self_and_descendents.pluck(:new_path), %w(
+    assert_equal node.self_and_descendants.pluck(:new_path), %w(
       Top.WoW
       Top.WoW.Amateurs_Astronomy
     )


### PR DESCRIPTION
…cendants.

It would be great to use descendants as the method for the descendants. I added deprecations for the methods with 'descendents' in the method naming such that people have the time to adjust their code.

See http://grammarist.com/usage/descendant-descendent/


Please note that the wiki needs updating after merging this PR.