### PR TITLE
Make depth work on new records

### DIFF
--- a/lib/pg_ltree/ltree.rb
+++ b/lib/pg_ltree/ltree.rb
@@ -116,7 +116,7 @@ module PgLtree
       #
       # @return [Integer] node depth
       def depth
-        ltree_scope.distinct.pluck("NLEVEL('#{ltree_path}')").first || nil
+        ActiveRecord::Base.connection.select_all("SELECT NLEVEL('#{ltree_path}')").cast_values.first
       end
 
       # Get root of the node

--- a/test/pg_ltree/ltree_test.rb
+++ b/test/pg_ltree/ltree_test.rb
@@ -78,6 +78,15 @@ class PgLtree::LtreeTest < ActiveSupport::TestCase
     assert_equal TreeNode.find_by(path: 'Top.Hobbies.Amateurs_Astronomy').depth, 3
   end
 
+  test '.depth on new record' do
+    assert_equal TreeNode.new(path: 'Top.Hobbies.Amateurs_Astronomy').depth, 3
+  end
+
+  test '.depth on new record when database is empty' do
+    TreeNode.delete_all
+    assert_equal TreeNode.new(path: 'Top.Hobbies.Amateurs_Astronomy').depth, 3
+  end
+
   test '.root' do
     assert_equal TreeNode.find_by(path: 'Top.Hobbies.Amateurs_Astronomy').root.path, 'Top'
   end
@@ -166,7 +175,7 @@ class PgLtree::LtreeTest < ActiveSupport::TestCase
       Top.WoW.Amateurs_Astronomy
     )
   end
-  
+
   test '.cascade_destroy' do
     TreeNode.find_by(path: 'Top.Collections').destroy
 


### PR DESCRIPTION
When calling depth on a new record, and when the database is emtpy depth returned nil
regardless of the path given.

This only occurred when the table associated with the pg_ltree_scope contained zero records. When there was at least one row for this table, the problem did not occur.

This change removes the dependency of having records for the concerned table in the database.