### PR TITLE
update dependency version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ gemfile:
   - gemfiles/activerecord_42_pg_017.gemfile
   - gemfiles/activerecord_42_pg_018.gemfile
   - gemfiles/activerecord_50_pg_018.gemfile
+  - gemfiles/activerecord_51_pg_020.gemfile
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,9 @@ matrix:
   exclude:
     - rvm: 2.0.0
       gemfile: gemfiles/activerecord_50_pg_018.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/activerecord_51_pg_020.gemfile
     - rvm: 2.1.8
       gemfile: gemfiles/activerecord_50_pg_018.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/activerecord_51_pg_020.gemfile

--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ It uses a implementation based around PostgreSQL's [ltree](http://www.postgresql
 [![RubyDoc](http://inch-ci.org/github/sjke/pg_ltree.svg?branch=master)](http://www.rubydoc.info/github/sjke/pg_ltree/)
 
 ## Support
-  This branch targets Rails 4, 5.0
   * ***Ruby*** 2.*
-  * ***Rails*** >= 4, < 5.1
-  * ***Pg addapter (gem 'pg')*** >= 0.17, < 0.19
+  * ***Rails*** >= 4, < 5.2
+  * ***Pg adapter (gem 'pg')*** >= 0.17, < 0.21
 
 ## Installation
 

--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ namespace :test do
     activerecord_40_pg_017 activerecord_40_pg_018
     activerecord_41_pg_017 activerecord_41_pg_018
     activerecord_42_pg_017 activerecord_42_pg_018
-    activerecord_50_pg_018
+    activerecord_50_pg_018 activerecord_51_pg_020
   ).freeze
 
   AVAILABLE_CASES.each do |version|

--- a/gemfiles/activerecord_51_pg_020.gemfile
+++ b/gemfiles/activerecord_51_pg_020.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '>= 5.1.0rc1', '< 5.2', require: 'active_record'
+gem 'pg', '>= 0.20.0', '< 0.21'
+
+gemspec path: '../'

--- a/pg_ltree.gemspec
+++ b/pg_ltree.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'activerecord', '>= 4.0.0', '< 5.1'
-  s.add_dependency 'pg', '>= 0.17.0', '< 0.19'
+  s.add_dependency 'activerecord', '>= 4.0.0', '< 5.2'
+  s.add_dependency 'pg', '>= 0.17.0', '< 0.21'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
I'm working on a project with Rails 5.1 and pg 0.20 and would like to use this gem. I've made the appropriate changes to reflect that this project supports these versions. Please let me know if you need me to update anything else. Thanks! 