### PR TITLE
add ltxtquery support

### DIFF
--- a/lib/pg_ltree/ltree.rb
+++ b/lib/pg_ltree/ltree.rb
@@ -59,6 +59,14 @@ module PgLtree
       def where_path_liked(lquery)
         where "#{ltree_path_column} ~ ?", lquery
       end
+
+      # Get all nodes with path matching full-text-search-like pattern
+      #
+      # @param ltxtquery [String] ltree search query
+      # @return [ActiveRecord::Relation] of matching nodes
+      def where_path_matches_ltxtquery(ltxtquery)
+        where "#{ltree_path_column} @ ?", ltxtquery
+      end
     end
 
     # Define instance methods

--- a/test/pg_ltree/ltree_test.rb
+++ b/test/pg_ltree/ltree_test.rb
@@ -60,6 +60,15 @@ class PgLtree::LtreeTest < BaseTest
     )
   end
 
+  test '#where_path_matches_ltxtquery' do
+    assert_equal TreeNode.where_path_matches_ltxtquery('Astro*% & !pictures@').pluck(:path), %w(
+      Top.Science.Astronomy
+      Top.Science.Astronomy.Astrophysics
+      Top.Science.Astronomy.Cosmology
+      Top.Hobbies.Amateurs_Astronomy
+    )
+  end
+
   test '.root?' do
     assert TreeNode.find_by(path: 'Top').root?
     assert_not TreeNode.find_by(path: 'Top.Science').root?


### PR DESCRIPTION
Adds a new convenience method to support ltxtquery value for searching. More info here: https://www.postgresql.org/docs/8.4/static/ltree.html

> ltxtquery represents a full-text-search-like pattern for matching ltree values. An ltxtquery value contains words, possibly with the modifiers @, *, % at the end; the modifiers have the same meanings as in lquery. Words can be combined with & (AND), | (OR), ! (NOT), and parentheses. The key difference from lquery is that ltxtquery matches words without regard to their position in the label path.

Here's an example ltxtquery:

     Europe & Russia*@ & !Transportation