### PR TITLE
Handle Rails 5.1 Deprecation Warning On Attribute_Was

### DIFF
--- a/lib/pg_ltree.rb
+++ b/lib/pg_ltree.rb
@@ -1,5 +1,6 @@
 require 'pg_ltree/ltree'
 require 'pg_ltree/scoped_for'
 require 'pg_ltree/version'
+require 'active_record'
 
 ActiveRecord::Base.extend(PgLtree::Ltree)

--- a/test/pg_ltree/ltree_test.rb
+++ b/test/pg_ltree/ltree_test.rb
@@ -69,10 +69,6 @@ class PgLtree::LtreeTest < BaseTest
     )
   end
 
-  test '#' do
-
-  end
-
   test '.root?' do
     assert TreeNode.find_by(path: 'Top').root?
     assert_not TreeNode.find_by(path: 'Top.Science').root?

--- a/test/pg_ltree/ltree_test.rb
+++ b/test/pg_ltree/ltree_test.rb
@@ -69,6 +69,10 @@ class PgLtree::LtreeTest < BaseTest
     )
   end
 
+  test '#' do
+
+  end
+
   test '.root?' do
     assert TreeNode.find_by(path: 'Top').root?
     assert_not TreeNode.find_by(path: 'Top.Science').root?
@@ -178,6 +182,13 @@ class PgLtree::LtreeTest < BaseTest
       Top.WoW
       Top.WoW.Amateurs_Astronomy
     )
+  end
+
+  test '.delete_ltree_column_value' do
+    node = TreeNode.find_by!(path: 'Top.Collections')
+    assert_equal node.ltree_path, 'Top.Collections'
+    node.delete_ltree_column_value
+    assert_nil node.ltree_path
   end
 
   test '.cascade_destroy' do


### PR DESCRIPTION
Rails 5.2 will change how attribute_was will work in Active Record. Per Rails upgrade policy, Rails 5.1 is now issuing warnings about this change when using the Ltree gem.

```
DEPRECATION WARNING: The behavior of `attribute_was` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `attribute_before_last_save` instead. (called from public_send at /Users/csun/Projects/hoyaboya/pg_ltree/lib/pg_ltree/ltree.rb:100)
```

This PR makes the required change and, unfortunately, has a bit of a hack to get the cascade destroy functionality to work as-is with a quick `update_attributes(ltree_column => nil)` to get the existing callbacks to all fire. For some reason, there is a discrepancy between `x_was` vs `x_before_last_save` and the value is not present with the Rails 5.1 change so this [test](https://github.com/sjke/pg_ltree/blob/master/test/pg_ltree/scoped_for_test.rb#L181) fails. 

Related Article
http://blog.toshima.ru/2017/04/06/saved-change-to-attribute.html

Related PR
https://github.com/rails/rails/pull/25337

I am open to suggestions on how to get this all to work without the hack.

/cc @sb1752 