### PR TITLE
Fix #leaves used with a custom relation

### DIFF
--- a/lib/pg_ltree/ltree.rb
+++ b/lib/pg_ltree/ltree.rb
@@ -44,12 +44,12 @@ module PgLtree
       #
       # @return [ActiveRecord::Relation] relations of node's leaves
       def leaves
-        subquery =
-          unscoped.select("COUNT(subquery.#{ltree_path_column}) = 1")
-                  .from("#{table_name} AS subquery")
-                  .where("subquery.#{ltree_path_column} <@ #{table_name}.#{ltree_path_column}")
-        subquery = subquery.where(subquery: current_scope.where_values_hash) if current_scope
-        where subquery.to_sql
+        subquery = unscoped.select("#{table_name}.#{ltree_path_column}")
+                           .from("#{table_name} AS subquery")
+                           .where("#{table_name}.#{ltree_path_column} <> subquery.#{ltree_path_column}")
+                           .where("#{table_name}.#{ltree_path_column} @> subquery.#{ltree_path_column}")
+
+        where.not ltree_path_column => subquery
       end
 
       # Get all with nodes when path liked the lquery

--- a/test/pg_ltree/ltree_test.rb
+++ b/test/pg_ltree/ltree_test.rb
@@ -53,6 +53,16 @@ class PgLtree::LtreeTest < BaseTest
     )
   end
 
+  test '#leaves with a relation' do
+    assert_equal TreeNode.where("path <> 'Top.Collections.Pictures.Astronomy.Stars'").leaves.pluck(:path), %w(
+      Top.Science.Astronomy.Astrophysics
+      Top.Science.Astronomy.Cosmology
+      Top.Hobbies.Amateurs_Astronomy
+      Top.Collections.Pictures.Astronomy.Galaxies
+      Top.Collections.Pictures.Astronomy.Astronauts
+    )
+  end
+
   test '#where_path_liked' do
     assert_equal TreeNode.where_path_liked('*{2}.Astronomy|Pictures').pluck(:path), %w(
       Top.Science.Astronomy


### PR DESCRIPTION
Currently `#leaves` doesn't work properly with chained custom relations.

The `#where_values_hash` method used in its implementation doesn't return every `where` condition, e.g. it ignores the ones passed as raw SQL fragment strings, leading to an empty hash which then causes the method to just return an empty array.

Here is a test case to illustrate the issue:

```ruby
TreeNode.where("path <> 'Top.Collections.Pictures.Astronomy.Stars'")
        .leaves
        .pluck(:path) #=> []
```

This PR fixes the issue by rewriting the query to check for leaf nodes based on https://stackoverflow.com/a/43512352.