### PR TITLE
fix error "undefined method `nil` for nil:NilClass" on Single Table Inheritance

### DIFF
--- a/lib/pg_ltree/base.rb
+++ b/lib/pg_ltree/base.rb
@@ -28,6 +28,10 @@ module PgLtree
         send(:include, PgLtree::Callbacks)
       end
 
+      def ltree_options
+        @ltree_options || superclass.ltree_options
+      end
+
       def ltree_option_for(key)
         ltree_options[key]
       end

--- a/spec/pg_ltree/base_spec.rb
+++ b/spec/pg_ltree/base_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe PgLtree::Base do
     end
   end
 
+  let!(:sub_class) do
+    Class.new(model_class) {}
+  end
+
   describe "inject PgLtree modules" do
     describe "when call #ltree" do
       subject { model_class.included_modules }
@@ -50,6 +54,10 @@ RSpec.describe PgLtree::Base do
       it "returns ltree option '#{key}' with '#{value}' as value" do
         expect(subject.ltree_option_for(key)).to eq(value)
       end
+    end
+
+    it "subclass of ltree can view options" do
+      expect(sub_class.ltree_options).to eq(cascade_destroy: true, cascade_update: true, column: :path)
     end
   end
 end


### PR DESCRIPTION
This PR fixes an error introduced in 1.2.0, where sub-classes would err on cascading updates and deletes.

```
full error:
     NoMethodError:

     undefined method `nil` for nil:NilClass

             ltree_options[key]
                          ^^^^^
```